### PR TITLE
added empty id protection, removed empty lines

### DIFF
--- a/gqlgen/graph/schema.resolvers.go
+++ b/gqlgen/graph/schema.resolvers.go
@@ -52,7 +52,7 @@ func (r *mutationResolver) DeleteQuote(ctx context.Context, id string) (*string,
 	}
 	var quote, _ = r.Query().QuoteByID(ctx, id)
 	if quote == nil || id == "" {
-		return nil, errors.New("error: ID not found")
+		return nil, errors.New("error: ID cannot be empty")
 	}
 	client := &http.Client{}
 	response, err := client.Do(request)

--- a/gqlgen/graph/schema.resolvers.go
+++ b/gqlgen/graph/schema.resolvers.go
@@ -30,9 +30,9 @@ func (r *mutationResolver) CreateQuote(ctx context.Context, input model.NewQuote
 	response, _ := client.Do(request)
 	switch response.StatusCode {
 	case 401:
-		return nil, errors.New("Error: " + response.Status)
+		return nil, errors.New("error: unauthorized")
 	case 400:
-		return nil, errors.New("Error: " + response.Status)
+		return nil, errors.New("error: quote and author must be at least 3 characters")
 	}
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
@@ -51,8 +51,11 @@ func (r *mutationResolver) DeleteQuote(ctx context.Context, id string) (*string,
 		return nil, err
 	}
 	var quote, _ = r.Query().QuoteByID(ctx, id)
-	if quote == nil || id == "" {
-		return nil, errors.New("error: ID cannot be empty")
+	if id == "" {
+		return nil, errors.New("error: id cannot be empty")
+	}
+	if quote == nil {
+		return nil, errors.New("error: invalid id")
 	}
 	client := &http.Client{}
 	response, err := client.Do(request)

--- a/gqlgen/graph/schema.resolvers.go
+++ b/gqlgen/graph/schema.resolvers.go
@@ -22,13 +22,10 @@ func (r *mutationResolver) CreateQuote(ctx context.Context, input model.NewQuote
 		Quote:  input.Quote,
 		Author: input.Author,
 	}
-
 	byteArray, _ := json.Marshal(quote)
 	buffer := bytes.NewBuffer(byteArray)
-
 	request, _ := http.NewRequest("POST", "http://34.160.33.1:80/quotes", buffer)
 	request.Header.Set("x-api-key", fmt.Sprint(ctx.Value("myKey")))
-
 	client := &http.Client{}
 	response, _ := client.Do(request)
 	switch response.StatusCode {
@@ -37,14 +34,11 @@ func (r *mutationResolver) CreateQuote(ctx context.Context, input model.NewQuote
 	case 400:
 		return nil, errors.New("Error: " + response.Status)
 	}
-
 	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, err
 	}
-
 	json.Unmarshal(data, quote)
-
 	return quote, nil
 }
 
@@ -57,7 +51,7 @@ func (r *mutationResolver) DeleteQuote(ctx context.Context, id string) (*string,
 		return nil, err
 	}
 	var quote, _ = r.Query().QuoteByID(ctx, id)
-	if quote == nil {
+	if quote == nil || id == "" {
 		return nil, errors.New("error: ID not found")
 	}
 	client := &http.Client{}
@@ -75,7 +69,6 @@ func (r *queryResolver) RandomQuote(ctx context.Context) (*model.Quote, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	client := &http.Client{}
 	response, _ := client.Do(request)
 	if response.Status == "401 Unauthorized" {
@@ -85,10 +78,8 @@ func (r *queryResolver) RandomQuote(ctx context.Context) (*model.Quote, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	var quote model.Quote
 	json.Unmarshal(data, &quote)
-
 	return &quote, nil
 }
 
@@ -97,16 +88,16 @@ func (r *queryResolver) QuoteByID(ctx context.Context, id string) (*model.Quote,
 	url := "http://34.160.33.1:80/quotes/" + id
 	request, err := http.NewRequest("GET", url, nil)
 	request.Header.Set("x-api-key", fmt.Sprint(ctx.Value("myKey")))
-	if err != nil {
-		return nil, err
+	if err != nil || id == "" {
+		return nil, errors.New("error: id cannot be empty")
 	}
 	client := &http.Client{}
 	response, _ := client.Do(request)
 	switch response.StatusCode {
 	case 401:
-		return nil, errors.New("Error: " + response.Status)
+		return nil, errors.New("error: " + response.Status)
 	case 404:
-		return nil, errors.New("Error: " + response.Status)
+		return nil, errors.New("error: " + response.Status)
 	}
 	data, err := io.ReadAll(response.Body)
 	if err != nil {

--- a/gqlgen/server.go
+++ b/gqlgen/server.go
@@ -24,18 +24,14 @@ func main() {
 	}
 	router := chi.NewRouter()
 	router.Use(Middleware())
-
 	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
-
 	router.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	router.Handle("/query", srv)
-
 	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
 	err := http.ListenAndServe(":"+port, router)
 	if err != nil {
 		panic(err)
 	}
-
 }
 
 func Middleware() func(http.Handler) http.Handler {
@@ -43,7 +39,6 @@ func Middleware() func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// put it in context
 			ctx := context.WithValue(r.Context(), "myKey", r.Header.Get("x-api-key"))
-
 			// and call the next with our new context
 			r = r.WithContext(ctx)
 			next.ServeHTTP(w, r)

--- a/main.go
+++ b/main.go
@@ -49,14 +49,12 @@ func connectUnixSocket() error {
 		}
 		return v
 	}
-
 	var (
 		dbUser         = mustGetenv("DB_USER")              // e.g. 'my-db-user'
 		dbPwd          = mustGetenv("NATE_PASSWORD")        // e.g. 'my-db-password'
 		unixSocketPath = mustGetenv("INSTANCE_UNIX_SOCKET") // e.g. '/cloudsql/project:region:instance' AKA HOST NAME
 		dbName         = mustGetenv("DB_NAME")              // e.g. 'my-database'
 	)
-
 	dbURI := fmt.Sprintf("user=%s password=%s database=%s host=%s",
 		dbUser, dbPwd, dbName, unixSocketPath)
 
@@ -66,9 +64,6 @@ func connectUnixSocket() error {
 	if err != nil {
 		return fmt.Errorf("sql.Open: %v", err)
 	}
-
-	// ...
-
 	return err
 }
 
@@ -77,11 +72,9 @@ func postQuote(c *gin.Context) {
 	q := &quote{}
 	var newID id
 	newID.ID = uuid.New().String()
-
 	if err := c.BindJSON(&q); err != nil {
 		return
 	}
-
 	if validateQuote(*q) && authenticate(c) {
 		sqlString := "INSERT INTO quotes (id, quote, author) VALUES ($1, $2, $3)"
 		_, err := pool.Exec(sqlString, &newID.ID, &q.Quote, &q.Author)


### PR DESCRIPTION
## ISSUE \#N/A

************************

## DESCRIPTION

Previously, the delete and get quote by id resolvers returned successful messages when an empty string was passed as the id. I have changed it so that they now tell the user that id cannot be empty.

## HOW TO TEST

Clone down the branch, run server.go from the `gqlgen` directory, and open the localhost address to access the GraphQL playground. Run the following queries, making sure to pass `COCKTAILSAUCE` as the `x-api-key` header:

    query getByID {
      quoteByID(id:""){
        id
        quote
        author
      }
    }

    mutation delete {
      deleteQuote(id: "")
    }

Confirm that the output is as expected. Thank you! ✌️